### PR TITLE
MozQuic: move receive buffer to the MozQuic class

### DIFF
--- a/netwerk/protocol/http/quic/mozquic/MozQuic.h
+++ b/netwerk/protocol/http/quic/mozquic/MozQuic.h
@@ -28,7 +28,7 @@ extern "C" {
 
   typedef void mozquic_connection_t;
 
-  struct mozquic_config_t 
+  struct mozquic_config_t
   {
     const char *originName;
     int originPort;

--- a/netwerk/protocol/http/quic/mozquic/MozQuicInternal.h
+++ b/netwerk/protocol/http/quic/mozquic/MozQuicInternal.h
@@ -90,6 +90,7 @@ private:
 
   uint32_t Transmit(unsigned char *, uint32_t len);
   uint32_t Recv(unsigned char *, uint32_t len, uint32_t &outLen, struct sockaddr_in *peer);
+  void Consumed(int bytes);
   int ProcessServerCleartext(unsigned char *, uint32_t size);
   int ProcessClientInitial(unsigned char *, uint32_t size, struct sockaddr_in *peer);
   int ProcessClientCleartext(unsigned char *pkt, uint32_t pktSize);
@@ -108,6 +109,9 @@ private:
   int Bind();
   bool VersionOK(uint32_t proposed);
   MozQuic *Accept(struct sockaddr_in *peer);
+
+  unsigned char mPkt[kMozQuicMSS]; // receive buffer
+  int mPktUsed;                    // bytes in in use
 
   int  mFD;
   bool mHandleIO;


### PR DESCRIPTION
... and make repeated small recvfrom() reads add data to the buffer to
make it more reliable. Requires that we call Consumed() with the number
of bytes "spent" from the receive buffer.