### PR TITLE
mozquic_socket_t: generic portable socket type

### DIFF
--- a/netwerk/protocol/http/quic/mozquic/MozQuic.cpp
+++ b/netwerk/protocol/http/quic/mozquic/MozQuic.cpp
@@ -78,13 +78,13 @@ extern "C" {
     return self->IO();
   }
 
-  int mozquic_osfd(mozquic_connection_t *conn)
+  mozquic_socket_t mozquic_osfd(mozquic_connection_t *conn)
   {
     mozilla::net::MozQuic *self(reinterpret_cast<mozilla::net::MozQuic *>(conn));
     return self->GetFD();
   }
 
-  void mozquic_setosfd(mozquic_connection_t *conn, int fd)
+  void mozquic_setosfd(mozquic_connection_t *conn, mozquic_socket_t fd)
   {
     mozilla::net::MozQuic *self(reinterpret_cast<mozilla::net::MozQuic *>(conn));
     self->SetFD(fd);
@@ -123,7 +123,7 @@ extern "C" {
 namespace mozilla { namespace net {
 
 MozQuic::MozQuic(bool handleIO)
-  : mFD(-1)
+  : mFD(MOZQUIC_SOCKET_BAD)
   , mHandleIO(handleIO)
   , mIsClient(true)
   , mIsChild(false)
@@ -154,7 +154,7 @@ MozQuic::MozQuic(bool handleIO)
 
 MozQuic::~MozQuic()
 {
-  if (!mIsChild && (mFD > 0)) {
+  if (!mIsChild && (mFD != MOZQUIC_SOCKET_BAD)) {
     close(mFD);
   }
 }
@@ -201,7 +201,7 @@ MozQuic::SetOriginName(const char *name)
 int
 MozQuic::Bind()
 {
-  if (mFD > 0) {
+  if (mFD != MOZQUIC_SOCKET_BAD) {
     return MOZQUIC_OK;
   }
   mFD = socket(AF_INET, SOCK_DGRAM, 0); // todo v6 and non 0 addr

--- a/netwerk/protocol/http/quic/mozquic/MozQuic.h
+++ b/netwerk/protocol/http/quic/mozquic/MozQuic.h
@@ -11,6 +11,18 @@
 */
 #include <stdint.h>
 
+#ifndef mozquic_socket_typedef
+/* socket typedef */
+#ifdef WIN32
+typedef SOCKET mozquic_socket_t;
+#define MOZQUIC_SOCKET_BAD INVALID_SOCKET
+#else
+typedef int mozquic_socket_t;
+#define MOZQUIC_SOCKET_BAD -1
+#endif
+#define mozquic_socket_typedef
+#endif /* mozquic_socket_typedef */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -60,8 +72,8 @@ extern "C" {
   int mozquic_IO(mozquic_connection_t *inSession);
   // todo need one to get the pollset
 
-  int  mozquic_osfd(mozquic_connection_t *inSession);
-  void mozquic_setosfd(mozquic_connection_t *inSession, int fd);
+  mozquic_socket_t mozquic_osfd(mozquic_connection_t *inSession);
+  void mozquic_setosfd(mozquic_connection_t *inSession, mozquic_socket_t fd);
 
   // the mozquic application may either delegate TLS handling to the lib
   // or may imlement the TLS API : mozquic_handshake_input/output and then

--- a/netwerk/protocol/http/quic/mozquic/MozQuicInternal.h
+++ b/netwerk/protocol/http/quic/mozquic/MozQuicInternal.h
@@ -81,7 +81,7 @@ public:
   void SetHandshakeInput(int (*fx)(mozquic_connection_t *,
                                    unsigned char *data, uint32_t len)) { mHandshakeInput = fx; }
   void SetErrorCB(int (*fx)(mozquic_connection_t *, uint32_t err, char *)) { mErrorCB = fx; }
-  void SetFD(int fd) { mFD = fd; }
+  void SetFD(mozquic_socket_t fd) { mFD = fd; }
   int  GetFD() { return mFD; }
 
   uint32_t DoWriter(std::unique_ptr<MozQuicStreamChunk> &p) override;
@@ -109,7 +109,7 @@ private:
   bool VersionOK(uint32_t proposed);
   MozQuic *Accept(struct sockaddr_in *peer);
 
-  int  mFD;
+  mozquic_socket_t mFD;
   bool mHandleIO;
   bool mIsClient;
   bool mIsChild;


### PR DESCRIPTION
... as 'int' doesn't play well on windows (since it is unsigned there
and can be 64 bit) and neither does using -1 for "illegal" value.